### PR TITLE
feat. (integ): Add support for rust integration tests in nix and codebuild

### DIFF
--- a/bindings/rust/standard/integration/src/capability_check.rs
+++ b/bindings/rust/standard/integration/src/capability_check.rs
@@ -58,7 +58,7 @@ impl Capability {
         match self {
             // OpenSSL 1.0.2 doesn't support RSA-PSS, so TLS 1.3 isn't enabled
             Capability::Tls13 => libcrypto != Libcrypto::OpenSsl102,
-            // AWS-LC: supports both ML-KEM + ML-DSA, AWSLCFIPS: supports ML-KEM
+            // AWS-LC supports both ML-KEM + ML-DSA but AWSLCFIPS only supports ML-KEM
             Capability::MLKem => matches!(libcrypto, Libcrypto::Awslc | Libcrypto::AwslcFips),
             Capability::MLDsa => matches!(libcrypto, Libcrypto::Awslc),
         }

--- a/bindings/rust/standard/integration/src/capability_check.rs
+++ b/bindings/rust/standard/integration/src/capability_check.rs
@@ -45,7 +45,8 @@ pub enum Capability {
     /// Support for TLS 1.3
     Tls13,
     /// Support for ML-DSA and ML-KEM
-    PQAlgorithms,
+    MLKem,
+    MLDsa,
 }
 
 impl Capability {
@@ -57,10 +58,9 @@ impl Capability {
         match self {
             // OpenSSL 1.0.2 doesn't support RSA-PSS, so TLS 1.3 isn't enabled
             Capability::Tls13 => libcrypto != Libcrypto::OpenSsl102,
-            // PQ is only supported for AWS-LC
-            Capability::PQAlgorithms => {
-                libcrypto == Libcrypto::Awslc || libcrypto == Libcrypto::AwslcFips
-            }
+            // AWS-LC: supports both ML-KEM + ML-DSA, AWSLCFIPS: supports ML-KEM
+            Capability::MLKem => matches!(libcrypto, Libcrypto::Awslc | Libcrypto::AwslcFips),
+            Capability::MLDsa => matches!(libcrypto, Libcrypto::Awslc),
         }
     }
 }

--- a/bindings/rust/standard/integration/src/capability_check.rs
+++ b/bindings/rust/standard/integration/src/capability_check.rs
@@ -29,7 +29,7 @@ impl Libcrypto {
 
         match libcrypto.as_str() {
             "awslc" => Libcrypto::Awslc,
-            "awslc-fips" => Libcrypto::AwslcFips,
+            "awslc-fips" | "awslc-fips-2022" | "awslc-fips-2024" => Libcrypto::AwslcFips,
             "openssl-1.0.2" => Libcrypto::OpenSsl102,
             "openssl-1.1.1" => Libcrypto::OpenSsl111,
             "openssl-3.0" => Libcrypto::OpenSsl30,

--- a/bindings/rust/standard/integration/src/features/pq.rs
+++ b/bindings/rust/standard/integration/src/features/pq.rs
@@ -22,7 +22,7 @@ pub async fn get_streams() -> Result<(TcpStream, TcpStream), tokio::io::Error> {
 
 #[test]
 fn s2n_mldsa_client() {
-    required_capability_async(&[Capability::PQAlgorithms], async {
+    required_capability_async(&[Capability::MLDsa], async {
         let cert_path = format!("{TEST_PEMS_PATH}mldsa/ML-DSA-87.crt");
         let key_path = format!("{TEST_PEMS_PATH}mldsa/ML-DSA-87-seed.priv");
 
@@ -68,7 +68,7 @@ fn s2n_mldsa_client() {
 
 #[test]
 fn s2n_mldsa_server() {
-    required_capability_async(&[Capability::PQAlgorithms], async {
+    required_capability_async(&[Capability::MLDsa], async {
         let cert_path = format!("{TEST_PEMS_PATH}mldsa/ML-DSA-87.crt");
         let key_path = format!("{TEST_PEMS_PATH}mldsa/ML-DSA-87-seed.priv");
 
@@ -109,7 +109,7 @@ fn s2n_mldsa_server() {
 
 #[test]
 fn s2n_mlkem_client() {
-    required_capability_async(&[Capability::PQAlgorithms], async {
+    required_capability_async(&[Capability::MLKem], async {
         let cert_path =
             format!("{TEST_PEMS_PATH}permutations/ec_ecdsa_p256_sha384/server-chain.pem");
         let key_path = format!("{TEST_PEMS_PATH}permutations/ec_ecdsa_p256_sha384/server-key.pem");
@@ -152,7 +152,7 @@ fn s2n_mlkem_client() {
 
 #[test]
 fn s2n_mlkem_server() {
-    required_capability_async(&[Capability::PQAlgorithms], async {
+    required_capability_async(&[Capability::MLKem], async {
         let cert_path =
             format!("{TEST_PEMS_PATH}permutations/ec_ecdsa_p256_sha384/server-chain.pem");
         let key_path = format!("{TEST_PEMS_PATH}permutations/ec_ecdsa_p256_sha384/server-key.pem");

--- a/codebuild/bin/install_s2n_head.sh
+++ b/codebuild/bin/install_s2n_head.sh
@@ -36,7 +36,7 @@ if [[ "$IN_NIX_SHELL" ]]; then
     # Make sure main is available in our workspace.
     # This is a workaround for the merge queue workflow.
     git fetch origin
-    git checkout main
+    git checkout nix-experimentation
     git checkout $CODEBUILD_SOURCE_VERSION
 else
     export DEST_DIR="$SRC_ROOT"/bin

--- a/codebuild/bin/install_s2n_head.sh
+++ b/codebuild/bin/install_s2n_head.sh
@@ -36,7 +36,7 @@ if [[ "$IN_NIX_SHELL" ]]; then
     # Make sure main is available in our workspace.
     # This is a workaround for the merge queue workflow.
     git fetch origin
-    git checkout nix-experimentation
+    git checkout main
     git checkout $CODEBUILD_SOURCE_VERSION
 else
     export DEST_DIR="$SRC_ROOT"/bin

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -40,6 +40,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          S2N_NO_HEADBUILD=1
 
     # AWSLC aarch64
     - identifier: Integ_awslc_aarch64_0
@@ -50,6 +51,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          S2N_NO_HEADBUILD=1
 
     # AWSLC-FIPS-2022
     - identifier: Integ_awslcfips2022_x86_64_0

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -40,7 +40,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
-          S2N_NO_HEADBUILD=1
+          S2N_NO_HEADBUILD: 1
 
     # AWSLC aarch64
     - identifier: Integ_awslc_aarch64_0
@@ -51,7 +51,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
-          S2N_NO_HEADBUILD=1
+          S2N_NO_HEADBUILD: 1
 
     # AWSLC-FIPS-2022
     - identifier: Integ_awslcfips2022_x86_64_0

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -62,6 +62,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2022
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          S2N_NO_HEADBUILD: 1
 
     # AWSLC-FIPS-2024
     - identifier: Integ_awslcfips2024_aarch64_0
@@ -72,6 +73,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2024
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          S2N_NO_HEADBUILD: 1
 
     # Openssl30 x86
     - identifier: Integ_openssl30_x86_0
@@ -82,6 +84,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#default
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          S2N_NO_HEADBUILD: 1
 
     # Openssl30 aarch64
     - identifier: Integ_openssl30_aarch64_0
@@ -92,6 +95,7 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#default
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          S2N_NO_HEADBUILD: 1
 
     # Openssl111 aarch64 only
     - identifier: Integ_openssl111_aarch64_0
@@ -102,7 +106,8 @@ batch:
         variables:
           NIXDEV_LIBCRYPTO: .#openssl111
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
-
+          S2N_NO_HEADBUILD: 1
+          
 phases:
   install:
     commands:

--- a/codebuild/spec/buildspec_rust_nix.yml
+++ b/codebuild/spec/buildspec_rust_nix.yml
@@ -117,16 +117,6 @@ batch:
           NIXDEV_LIBCRYPTO: .#awslcfips2024
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
 
-    # AWS-LC FIPS 2024 aarch64
-    - identifier: Rust_awslcfips2024_aarch64_0
-      depend-on:
-        - nixCache_aarch64
-      env:
-        fleet: ubuntu24_aarch64_nix
-        variables:
-          NIXDEV_LIBCRYPTO: .#awslcfips2024
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
-
 phases:
   install:
     commands:

--- a/codebuild/spec/buildspec_rust_nix.yml
+++ b/codebuild/spec/buildspec_rust_nix.yml
@@ -1,0 +1,158 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Rust integration tests across crypto libraries using Nix
+---
+version: 0.2
+env:
+  shell: bash
+
+batch:
+  build-graph:
+    # Cache job for x86
+    - identifier: nixCache_x86_64
+      env:
+        fleet: ubuntu24_x86_64_nix
+        variables:
+          NIXDEV_ARGS: --max-jobs auto
+          NIXDEV_LIBCRYPTO: .#default
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # Cache Job for aarch64
+    - identifier: nixCache_aarch64
+      env:
+        fleet: ubuntu24_aarch64_nix
+        variables:
+          NIXDEV_ARGS: --max-jobs auto
+          NIXDEV_LIBCRYPTO: .#default
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # OpenSSL 1.0.2 x86
+    - identifier: Rust_openssl102_x86_0
+      depend-on:
+        - nixCache_x86_64
+      env:
+        fleet: ubuntu24_x86_64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#openssl102
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # OpenSSL 1.0.2 aarch64
+    - identifier: Rust_openssl102_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        fleet: ubuntu24_aarch64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#openssl102
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # OpenSSL 1.1.1 x86
+    - identifier: Rust_openssl111_x86_0
+      depend-on:
+        - nixCache_x86_64
+      env:
+        fleet: ubuntu24_x86_64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#openssl111
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # OpenSSL 1.1.1 aarch64
+    - identifier: Rust_openssl111_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        fleet: ubuntu24_aarch64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#openssl111
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # OpenSSL 3.0 x86
+    - identifier: Rust_openssl30_x86_0
+      depend-on:
+        - nixCache_x86_64
+      env:
+        fleet: ubuntu24_x86_64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#default
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # OpenSSL 3.0 aarch64
+    - identifier: Rust_openssl30_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        fleet: ubuntu24_aarch64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#default
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # AWS-LC x86
+    - identifier: Rust_awslc_x86_0
+      depend-on:
+        - nixCache_x86_64
+      env:
+        fleet: ubuntu24_x86_64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#awslc
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # AWS-LC aarch64
+    - identifier: Rust_awslc_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        fleet: ubuntu24_aarch64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#awslc
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # AWS-LC FIPS 2024 x86
+    - identifier: Rust_awslcfips2024_x86_0
+      depend-on:
+        - nixCache_x86_64
+      env:
+        fleet: ubuntu24_x86_64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#awslcfips2024
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # AWS-LC FIPS 2024 aarch64
+    - identifier: Rust_awslcfips2024_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        fleet: ubuntu24_aarch64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#awslcfips2024
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+phases:
+  install:
+    commands:
+      - if [[ $(date +%u) -eq 0 ]]; then nix store gc; fi
+      - |
+        if [[ $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          echo "Refreshing nix cache..."
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+          nix build .#devShell
+          nix copy --to $NIX_CACHE_BUCKET .#devShell
+        else
+          echo "Downloading cache"
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+        fi
+  pre_build:
+    commands:
+      - |
+        set -e
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+        fi
+  build:
+    commands:
+      - |
+        set -e
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          echo "Running Rust integration tests with $NIXDEV_LIBCRYPTO"
+          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; rust_integration"
+        fi

--- a/codebuild/spec/buildspec_rust_nix.yml
+++ b/codebuild/spec/buildspec_rust_nix.yml
@@ -117,6 +117,16 @@ batch:
           NIXDEV_LIBCRYPTO: .#awslcfips2024
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
 
+    # AWS-LC FIPS 2024 aarch64
+    - identifier: Rust_awslcfips2024_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        fleet: ubuntu24_aarch64_nix
+        variables:
+          NIXDEV_LIBCRYPTO: .#awslcfips2024
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
 phases:
   install:
     commands:
@@ -146,3 +156,4 @@ phases:
           echo "Running Rust integration tests with $NIXDEV_LIBCRYPTO"
           nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; rust_integration"
         fi
+        

--- a/codebuild/spec/buildspec_rust_nix.yml
+++ b/codebuild/spec/buildspec_rust_nix.yml
@@ -153,6 +153,13 @@ phases:
       - |
         set -e
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; build"
+        fi
+  post_build:
+    commands:
+      - |
+        set -e
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
           echo "Running Rust integration tests with $NIXDEV_LIBCRYPTO"
           nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; rust_integration"
         fi

--- a/codebuild/spec/buildspec_rust_nix.yml
+++ b/codebuild/spec/buildspec_rust_nix.yml
@@ -141,8 +141,8 @@ phases:
   build:
     commands:
       - |
-        set -Eeuo pipefail
+        set -e
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
           echo "Running Rust integration tests with $NIXDEV_LIBCRYPTO"
-          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c 'source ./nix/shell.sh; rust_integration'
+          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; rust_integration"
         fi

--- a/codebuild/spec/buildspec_rust_nix.yml
+++ b/codebuild/spec/buildspec_rust_nix.yml
@@ -151,15 +151,8 @@ phases:
   build:
     commands:
       - |
-        set -e
-        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; build"
-        fi
-  post_build:
-    commands:
-      - |
-        set -e
+        set -Eeuo pipefail
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
           echo "Running Rust integration tests with $NIXDEV_LIBCRYPTO"
-          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; rust_integration"
+          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c 'source ./nix/shell.sh; rust_integration'
         fi

--- a/flake.nix
+++ b/flake.nix
@@ -39,19 +39,18 @@
           pkgs.gnutls
           pkgs.tshark
 
-          # Toolchains and build tools (from Nix)
+          # Build configuration systems 
           pkgs.cmake
-          pkgs.ninja
 
-          # C Compiler Tooling; adding llvm/clang is an involved future task.
+          # C Compiler Tooling
           pkgs.gcc
           pkgs.gdb
           pkgs.valgrind
-
-          # *** Add Clang + LLVM binutils from Nix ***
           pkgs.llvmPackages_18.clang
-          pkgs.llvmPackages_18.bintools   # ar/nm/ranlib/objcopy from LLVM
-          pkgs.llvmPackages_18.libclang
+          pkgs.llvmPackages_18.bintools
+
+          # Compiler library
+          pkgs.llvmPackages_18.libclang # Provides libclang for Rust bindgen
 
           # Linters/Formatters
           pkgs.shellcheck

--- a/flake.nix
+++ b/flake.nix
@@ -39,10 +39,19 @@
           pkgs.gnutls
           pkgs.tshark
 
+          # Toolchains and build tools (from Nix)
+          pkgs.cmake
+          pkgs.ninja
+
           # C Compiler Tooling; adding llvm/clang is an involved future task.
           pkgs.gcc
           pkgs.gdb
           pkgs.valgrind
+
+          # *** Add Clang + LLVM binutils from Nix ***
+          pkgs.llvmPackages_18.clang
+          pkgs.llvmPackages_18.bintools   # ar/nm/ranlib/objcopy from LLVM
+          pkgs.llvmPackages_18.libclang
 
           # Linters/Formatters
           pkgs.shellcheck

--- a/flake.nix
+++ b/flake.nix
@@ -44,9 +44,6 @@
           pkgs.gdb
           pkgs.valgrind
 
-          # Add LLVM binutils from Nix for objcopy
-          pkgs.llvmPackages_18.bintools   
-
           # Linters/Formatters
           pkgs.shellcheck
           # There are 2 nix formatters; use the old one for now.

--- a/flake.nix
+++ b/flake.nix
@@ -39,10 +39,18 @@
           pkgs.gnutls
           pkgs.tshark
 
+          # Toolchains and build tools (from Nix)
+          pkgs.cmake
+          pkgs.ninja
+
           # C Compiler Tooling; adding llvm/clang is an involved future task.
           pkgs.gcc
           pkgs.gdb
           pkgs.valgrind
+
+          # *** Add Clang + LLVM binutils from Nix ***
+          pkgs.llvmPackages_18.clang
+          pkgs.llvmPackages_18.bintools   # ar/nm/ranlib/objcopy from LLVM
 
           # Linters/Formatters
           pkgs.shellcheck

--- a/flake.nix
+++ b/flake.nix
@@ -39,18 +39,13 @@
           pkgs.gnutls
           pkgs.tshark
 
-          # Toolchains and build tools (from Nix)
-          pkgs.cmake
-          pkgs.ninja
-
           # C Compiler Tooling; adding llvm/clang is an involved future task.
           pkgs.gcc
           pkgs.gdb
           pkgs.valgrind
 
-          # *** Add Clang + LLVM binutils from Nix ***
-          pkgs.llvmPackages_18.clang
-          pkgs.llvmPackages_18.bintools   # ar/nm/ranlib/objcopy from LLVM
+          # Add LLVM binutils from Nix for objcopy
+          pkgs.llvmPackages_18.bintools   
 
           # Linters/Formatters
           pkgs.shellcheck

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -2,115 +2,144 @@
 , aws-lc, aws-lc-fips-2022, aws-lc-fips-2024, writeScript }:
 
 let
+  # Shared shellHook to force Nix toolchain paths for CMake discovery
+  commonShellHook = ''
+    # Prefer Nix-provided Clang/LLVM tools (avoid /usr/bin)
+    export CC="$(command -v clang)"
+    export CXX="$(command -v clang++)"
+    export AR="$(command -v llvm-ar || command -v ar)"
+    export NM="$(command -v llvm-nm || command -v nm)"
+    export RANLIB="$(command -v llvm-ranlib || command -v ranlib)"
+    export OBJCOPY="$(command -v llvm-objcopy || command -v objcopy)"
+
+    # Optional: prefer Ninja if present (faster/more deterministic)
+    if command -v ninja >/dev/null 2>&1; then
+      export CMAKE_GENERATOR="Ninja"
+    fi
+
+    echo "Toolchain:"
+    echo "  CC=$CC"
+    echo "  CXX=$CXX"
+    echo "  AR=$AR"
+    echo "  NM=$NM"
+    echo "  RANLIB=$RANLIB"
+    echo "  OBJCOPY=$OBJCOPY"
+  '';
+
   # Define the default devShell
   default = pkgs.mkShell {
-    # This is a development environment shell which should be able to:
-    #  - build s2n-tls
-    #  - run unit tests
-    #  - run integ tests
-    #  - do common development operations (e.g. lint, debug, and manage repos)
     inherit system;
+    # keep minimal buildInputs; most tools come via `packages = common_packages`
     buildInputs = [ pkgs.cmake openssl_3_0 ];
     packages = common_packages;
+
     S2N_LIBCRYPTO = "openssl-3.0";
-    # Only set OPENSSL_1_0_2_INSTALL_DIR when OpenSSL 1.0.2 is available
     OPENSSL_1_0_2_INSTALL_DIR =
       if openssl_1_0_2 != null then "${openssl_1_0_2}" else "";
     OPENSSL_1_1_1_INSTALL_DIR = "${openssl_1_1_1}";
-    OPENSSL_3_0_INSTALL_DIR = "${openssl_3_0}";
-    AWSLC_INSTALL_DIR = "${aws-lc}";
+    OPENSSL_3_0_INSTALL_DIR   = "${openssl_3_0}";
+    AWSLC_INSTALL_DIR         = "${aws-lc}";
     AWSLC_FIPS_2022_INSTALL_DIR = "${aws-lc-fips-2022}";
     AWSLC_FIPS_2024_INSTALL_DIR = "${aws-lc-fips-2024}";
-    GNUTLS_INSTALL_DIR = "${pkgs.gnutls}";
-    LIBRESSL_INSTALL_DIR = "${pkgs.libressl}";
-    # Integ s_client/server tests expect openssl 1.1.1.
+    GNUTLS_INSTALL_DIR        = "${pkgs.gnutls}";
+    LIBRESSL_INSTALL_DIR      = "${pkgs.libressl}";
+
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
+      # Integ s_client/server tests expect openssl 1.1.1 on PATH
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
+
+      ${commonShellHook}
+
+      # project shell script
       source ${writeScript ./shell.sh}
     '';
   };
 
   # Define the openssl111 devShell
   openssl111 = default.overrideAttrs (finalAttrs: previousAttrs: {
-    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake openssl_1_1_1 ];
     S2N_LIBCRYPTO = "openssl-1.1.1";
-    # Integ s_client/server tests expect openssl 1.1.1.
-    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
+
+      ${commonShellHook}
+
       source ${writeScript ./shell.sh}
     '';
   });
 
   # Define the libressl devShell
   libressl_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
-    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake pkgs.libressl ];
     S2N_LIBCRYPTO = "libressl";
-    # Integ s_client/server tests expect openssl 1.1.1.
-    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
+
+      ${commonShellHook}
+
       source ${writeScript ./shell.sh}
     '';
   });
 
   openssl102 = default.overrideAttrs (finalAttrs: previousAttrs: {
-    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake openssl_1_0_2 ];
     S2N_LIBCRYPTO = "openssl-1.0.2";
-    # Integ s_client/server tests expect openssl 1.1.1.
-    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
+
+      ${commonShellHook}
+
       source ${writeScript ./shell.sh}
     '';
   });
 
   # Define the awslc devShell
   awslc_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
-    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake aws-lc ];
     S2N_LIBCRYPTO = "awslc";
-    # Integ s_client/server tests expect openssl 1.1.1.
-    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
+
+      ${commonShellHook}
+
       source ${writeScript ./shell.sh}
     '';
   });
 
   awslcfips2022_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
-    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake aws-lc-fips-2022 ];
     S2N_LIBCRYPTO = "awslc-fips-2022";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
+
+      ${commonShellHook}
+
       source ${writeScript ./shell.sh}
     '';
   });
 
   awslcfips2024_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
-    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake aws-lc-fips-2024 ];
     S2N_LIBCRYPTO = "awslc-fips-2024";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
+
+      ${commonShellHook}
+
       source ${writeScript ./shell.sh}
     '';
   });

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -40,6 +40,18 @@ let
       fi
   )"
   '';
+
+  commonToolInputs = [
+    pkgs.llvmPackages_18.clang
+    pkgs.llvmPackages_18.lld
+    pkgs.cmake
+    pkgs.ninja
+    pkgs.pkg-config
+    pkgs.rustc
+    pkgs.cargo
+    pkgs.rustfmt
+  ];
+
   awsLcStatic = aws-lc.overrideAttrs (old: {
     cmakeFlags = (old.cmakeFlags or []) ++ [
       "-DBUILD_SHARED_LIBS=OFF"
@@ -58,7 +70,7 @@ let
   default = pkgs.mkShell {
     inherit system;
     # keep minimal buildInputs; most tools come via `packages = common_packages`
-    buildInputs = [ pkgs.cmake openssl_3_0 ];
+    buildInputs = commonToolInputs ++ [ pkgs.cmake openssl_3_0 ];
     packages = common_packages;
 
     S2N_LIBCRYPTO = "openssl-3.0";
@@ -87,7 +99,7 @@ let
 
   # Define the openssl111 devShell
   openssl111 = default.overrideAttrs (finalAttrs: previousAttrs: {
-    buildInputs = [ pkgs.cmake openssl_1_1_1 ];
+    buildInputs = commonToolInputs ++ [ pkgs.cmake openssl_1_1_1 ];
     S2N_LIBCRYPTO = "openssl-1.1.1";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
@@ -102,7 +114,7 @@ let
 
   # Define the libressl devShell
   libressl_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
-    buildInputs = [ pkgs.cmake pkgs.libressl ];
+    buildInputs = commonToolInputs ++ [ pkgs.cmake pkgs.libressl ];
     S2N_LIBCRYPTO = "libressl";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
@@ -116,7 +128,7 @@ let
   });
 
   openssl102 = default.overrideAttrs (finalAttrs: previousAttrs: {
-    buildInputs = [ pkgs.cmake openssl_1_0_2 ];
+    buildInputs = commonToolInputs ++ [ pkgs.cmake openssl_1_0_2 ];
     S2N_LIBCRYPTO = "openssl-1.0.2";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
@@ -131,7 +143,7 @@ let
 
   # Define the awslc devShell
   awslc_shell = default.overrideAttrs (final: prev: {
-    buildInputs = [ pkgs.cmake awsLcStatic ];
+    buildInputs = commonToolInputs ++ [ pkgs.cmake awsLcStatic ];
     S2N_LIBCRYPTO = "awslc";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
@@ -145,7 +157,7 @@ let
   });
 
   awslcfips2022_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
-    buildInputs = [ pkgs.cmake aws-lc-fips-2022 ];
+    buildInputs = commonToolInputs ++ [ pkgs.cmake aws-lc-fips-2022 ];
     S2N_LIBCRYPTO = "awslc-fips-2022";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
@@ -159,7 +171,7 @@ let
   });
 
   awslcfips2024_shell = default.overrideAttrs (final: prev: {
-    buildInputs = [ pkgs.cmake awsLcFips2024Static ];
+    buildInputs = commonToolInputs ++ [ pkgs.cmake awsLcFips2024Static ];
     S2N_LIBCRYPTO = "awslc-fips-2024";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -2,35 +2,24 @@
 , aws-lc, aws-lc-fips-2022, aws-lc-fips-2024, writeScript }:
 
 let
-  commonShellHook = ''
-    export CC="$(command -v clang)"
-    export CXX="$(command -v clang++)"
-    export AR="$(command -v llvm-ar || command -v ar)"
-    if command -v ninja >/dev/null 2>&1; then
-      export CMAKE_GENERATOR="Ninja"
-    fi
-  '';
-  awsLcStatic = aws-lc.overrideAttrs (old: {
-    cmakeFlags = (old.cmakeFlags or []) ++ [
-      "-DBUILD_SHARED_LIBS=OFF"
-      "-DBUILD_TESTING=OFF"
-    ];
+  # Static AWS-LC builds to avoid Rust integration conflicts
+  makeStatic = drv: drv.overrideAttrs (old: {
+    cmakeFlags = (old.cmakeFlags or []) ++ [ "-DBUILD_SHARED_LIBS=OFF" ];
   });
-  
-  awsLcFips2024Static = aws-lc-fips-2024.overrideAttrs (old: {
-    cmakeFlags = (old.cmakeFlags or []) ++ [
-      "-DBUILD_SHARED_LIBS=OFF"
-      "-DBUILD_TESTING=OFF"
-    ];
-  });
+  awsLcStatic        = makeStatic aws-lc;
+  awsLcFips2024Static = makeStatic aws-lc-fips-2024;
 
   # Define the default devShell
   default = pkgs.mkShell {
+    # This is a development environment shell which should be able to:
+    #  - build s2n-tls
+    #  - run unit tests
+    #  - run integ tests
+    #  - do common development operations (e.g. lint, debug, and manage repos)
     inherit system;
     # keep minimal buildInputs; most tools come via `packages = common_packages`
     buildInputs = [ pkgs.cmake openssl_3_0 ];
     packages = common_packages;
-
     S2N_LIBCRYPTO = "openssl-3.0";
     OPENSSL_1_0_2_INSTALL_DIR =
       if openssl_1_0_2 != null then "${openssl_1_0_2}" else "";
@@ -41,15 +30,12 @@ let
     AWSLC_FIPS_2024_INSTALL_DIR = "${aws-lc-fips-2024}";
     GNUTLS_INSTALL_DIR        = "${pkgs.gnutls}";
     LIBRESSL_INSTALL_DIR      = "${pkgs.libressl}";
-
+    # Integ s_client/server tests expect openssl 1.1.1.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       # Integ s_client/server tests expect openssl 1.1.1 on PATH
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
-
-      ${commonShellHook}
-
       # project shell script
       source ${writeScript ./shell.sh}
     '';
@@ -57,78 +43,79 @@ let
 
   # Define the openssl111 devShell
   openssl111 = default.overrideAttrs (finalAttrs: previousAttrs: {
+    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake openssl_1_1_1 ];
     S2N_LIBCRYPTO = "openssl-1.1.1";
+    # Integ s_client/server tests expect openssl 1.1.1.
+    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
-
-      ${commonShellHook}
-
       source ${writeScript ./shell.sh}
     '';
   });
 
   # Define the libressl devShell
   libressl_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
+    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake pkgs.libressl ];
     S2N_LIBCRYPTO = "libressl";
+    # Integ s_client/server tests expect openssl 1.1.1.
+    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
-
-      ${commonShellHook}
-
       source ${writeScript ./shell.sh}
     '';
   });
 
   openssl102 = default.overrideAttrs (finalAttrs: previousAttrs: {
+    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake openssl_1_0_2 ];
     S2N_LIBCRYPTO = "openssl-1.0.2";
+    # Integ s_client/server tests expect openssl 1.1.1.
+    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
-
-      ${commonShellHook}
-
       source ${writeScript ./shell.sh}
     '';
   });
 
   # Define the awslc devShell
   awslc_shell = default.overrideAttrs (final: prev: {
+    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake awsLcStatic ];
     S2N_LIBCRYPTO = "awslc";
+    # Integ s_client/server tests expect openssl 1.1.1.
+    # GnuTLS-cli and serv utilities needed for some integration tests.
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
       # Prefer aws-lc’s dev+lib outputs so CMake sees static targets
       export CMAKE_PREFIX_PATH="${awsLcStatic}''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
-      ${commonShellHook}
       source ${writeScript ./shell.sh}
     '';
   });
 
   awslcfips2022_shell = default.overrideAttrs (finalAttrs: previousAttrs: {
+    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake aws-lc-fips-2022 ];
     S2N_LIBCRYPTO = "awslc-fips-2022";
     shellHook = ''
       echo Setting up $S2N_LIBCRYPTO environment from flake.nix...
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
-
-      ${commonShellHook}
-
       source ${writeScript ./shell.sh}
     '';
   });
 
   awslcfips2024_shell = default.overrideAttrs (final: prev: {
+    # Re-include cmake to update the environment with a new libcrypto.
     buildInputs = [ pkgs.cmake awsLcFips2024Static ];
     S2N_LIBCRYPTO = "awslc-fips-2024";
     shellHook = ''
@@ -136,7 +123,6 @@ let
       export PATH=${openssl_1_1_1}/bin:$PATH
       export PS1="[nix $S2N_LIBCRYPTO] $PS1"
       export CMAKE_PREFIX_PATH="${awsLcFips2024Static}''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
-      ${commonShellHook}
       source ${writeScript ./shell.sh}
     '';
   });

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -232,26 +232,9 @@ function rust_integration(){
         -D BUILD_TESTING=OFF \
 	    -D S2N_INTERN_LIBCRYPTO=ON
     cmake --build ./build -j $(nproc)
-    # Run the generator exactly as before, but in a subshell so any `exit`
-    # inside the script cannot terminate this shell.
-
-    (  # <-- subshell starts
-    set -euo pipefail
     bindings/rust/extended/generate.sh --skip-tests
-    )
-
-    # Now run Rust tests (still in the same devShell)
-    export S2N_TLS_LIB_DIR="$PWD/build/lib"
-    export S2N_TLS_INCLUDE_DIR="$PWD/api"
-
-    # Prefer a real cargo over rustup’s shim if present
-    if cargo --version 2>&1 | grep -q 'rustup could not choose'; then
-        CARGO_BIN="$(type -a -p cargo 2>/dev/null | grep -v '/rustup-.*/bin/cargo' | head -n1 || true)"
-        [[ -z "$CARGO_BIN" ]] && CARGO_BIN="$(ls -1d /nix/store/*-cargo-*/bin/cargo 2>/dev/null | head -n1 || true)"
-    else
-        CARGO_BIN="$(command -v cargo)"
-    fi
-
-    "$CARGO_BIN" --version
-    "$CARGO_BIN" test --manifest-path bindings/rust/standard/integration/Cargo.toml 
+    which -a cargo
+    export S2N_TLS_LIB_DIR=$(pwd)/build/lib
+    export S2N_TLS_INCLUDE_DIR=$(pwd)/api
+    cargo test --manifest-path bindings/rust/standard/integration/Cargo.toml 
 }

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -235,5 +235,7 @@ function rust_integration(){
     bindings/rust/extended/generate.sh --skip-tests
     export S2N_TLS_LIB_DIR=$(pwd)/build/lib
     export S2N_TLS_INCLUDE_DIR=$(pwd)/api
+    command -v cargo
+    cargo --version
     cargo test --manifest-path bindings/rust/standard/integration/Cargo.toml 
 }

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -240,12 +240,19 @@ rust_integration() {
     -D S2N_INTERN_LIBCRYPTO=ON
   cmake --build ./build -j"$(nproc)"
 
+# after cmake --build ...
+export S2N_TLS_LIB_DIR="$PWD/build/lib"
+export S2N_TLS_INCLUDE_DIR="$PWD/api"   
+
+# Ensure bindgen sees the API headers
+EXTRA_INC="-I$S2N_TLS_INCLUDE_DIR"
+
 # run generator without exiting the parent shell
 (
   set -euo pipefail
-  pushd bindings/rust/extended/generate
+  cd bindings/rust/extended/generate
+  BINDGEN_EXTRA_CLANG_ARGS="$BINDGEN_EXTRA_CLANG_ARGS -I$S2N_TLS_INCLUDE_DIR" \
   cargo run -- ../s2n-tls-sys
-  popd
 )
 
   echo ">>> generator done; continuing to cargo tests"

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -233,7 +233,7 @@ function rust_integration(){
 	    -D S2N_INTERN_LIBCRYPTO=ON
     cmake --build ./build -j $(nproc)
     bindings/rust/extended/generate.sh --skip-tests
-    # Use workspace-local, writable homes (important in CI)
+    
     export RUSTUP_HOME="$PWD/.rustup"
     export CARGO_HOME="$PWD/.cargo"
 

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -233,20 +233,15 @@ function rust_integration(){
 	    -D S2N_INTERN_LIBCRYPTO=ON
     cmake --build ./build -j $(nproc)
     bindings/rust/extended/generate.sh --skip-tests
-    
     export RUSTUP_HOME="$PWD/.rustup"
     export CARGO_HOME="$PWD/.cargo"
-
     rustup set profile minimal
     rustup set auto-self-update disable
-
     TOOLCHAIN="stable"   
     rustup toolchain install "$TOOLCHAIN" --component rustfmt --component clippy
     rustup default "$TOOLCHAIN"
-
     export PATH="$CARGO_HOME/bin:$PATH"
     hash -r
-
     cargo --version
     rustc --version
     export S2N_TLS_LIB_DIR=$(pwd)/build/lib

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -233,28 +233,23 @@ function rust_integration(){
 	    -D S2N_INTERN_LIBCRYPTO=ON
     cmake --build ./build -j $(nproc)
     bindings/rust/extended/generate.sh --skip-tests
-    export S2N_TLS_LIB_DIR="$REPO_ROOT/build/lib"
-    export S2N_TLS_INCLUDE_DIR="$REPO_ROOT/api"
+    # Use workspace-local, writable homes (important in CI)
+    export RUSTUP_HOME="$PWD/.rustup"
+    export CARGO_HOME="$PWD/.cargo"
 
-    echo "All cargos on PATH:"
-    type -a -p cargo || true
+    rustup set profile minimal
+    rustup set auto-self-update disable
 
-    # === Pick non-rustup cargo (SAFEST) ===
-    CARGO_BIN="$(type -a -p cargo 2>/dev/null | grep -v '/rustup-.*/bin/cargo' | head -n1 || true)"
-    [[ -z "$CARGO_BIN" ]] && CARGO_BIN="$(ls -1d /nix/store/*-cargo-*/bin/cargo 2>/dev/null | head -n1 || true)"
+    TOOLCHAIN="stable"   
+    rustup toolchain install "$TOOLCHAIN" --component rustfmt --component clippy
+    rustup default "$TOOLCHAIN"
 
-    # Fallback: initialize rustup toolchain only if no real cargo found
-    if [[ -z "$CARGO_BIN" ]]; then
-        echo "No non-rustup cargo on PATH; bootstrapping rustup toolchain..."
-        export RUSTUP_HOME="$REPO_ROOT/.rustup"
-        export CARGO_HOME="$REPO_ROOT/.cargo"
-        rustup set profile minimal
-        rustup toolchain install 1.82.0 --component rustfmt
-        rustup default 1.82.0
-        CARGO_BIN="$(command -v cargo)"
-    fi
+    export PATH="$CARGO_HOME/bin:$PATH"
+    hash -r
 
-    echo "Using cargo: $CARGO_BIN"
-    "$CARGO_BIN" --version
-    "$CARGO_BIN" test --manifest-path "$REPO_ROOT/bindings/rust/standard/integration/Cargo.toml" 
+    cargo --version
+    rustc --version
+    export S2N_TLS_LIB_DIR=$(pwd)/build/lib
+    export S2N_TLS_INCLUDE_DIR=$(pwd)/api
+    cargo test --manifest-path bindings/rust/standard/integration/Cargo.toml 
 }


### PR DESCRIPTION
### Release Summary:
Adds Nix + CodeBuild support to run the Rust integration test suite across multiple libcryptos (OpenSSL 1.0.2, 1.1.1, 3.0; AWS-LC; AWS-LC-FIPS 2022/2024) on x86_64 and aarch64 fleets. Also clarifies PQ feature-gating by splitting PQAlgorithms into distinct MLKem and MLDsa capabilities and updating tests accordingly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
